### PR TITLE
Replace all "intel" markers with local player diary entries

### DIFF
--- a/core/doc.sqf
+++ b/core/doc.sqf
@@ -1,6 +1,8 @@
 private _MainCategory = localize "str_3den_display3den_menubar_helpdoc_text";
 player createDiarySubject [_MainCategory, _MainCategory];
-player createDiarySubject [localize "STR_BTC_HAM_CON_INFO_ASKHIDEOUT_DIARYLOG", localize "STR_BTC_HAM_CON_INFO_ASKHIDEOUT_DIARYLOG"];
+private _infoLog = localize "STR_HM_DIARY_INFO";
+player createDiarySubject [_infoLog, localize "STR_HM_DIARY_INFO"];
+player createDiaryRecord [_infoLog, [localize "STR_HM_DIARY_INFO_README", localize "STR_HM_DIARY_INFO_README_TEXT"]];
 
 //Headless and Data base
 player createDiaryRecord [_MainCategory, [localize "STR_BTC_HAM_DOC_HEADLESS_TITLE", localize "STR_BTC_HAM_DOC_HEADLESS_TEXT"]];

--- a/core/fnc/info/ask.sqf
+++ b/core/fnc/info/ask.sqf
@@ -3,46 +3,61 @@
 Function: btc_fnc_info_ask
 
 Description:
-    Fill me when you edit me !
+    ACE Interaction action handler for questioning people.
 
 Parameters:
-    _man - [Object]
-    _isInterrogate - [Boolean]
+    _target - Target of the interaction. [Object]
+    _player - The player who performed the interaction. [Object]
+    _args - Custom arguments. [Array]:
+        0: _isInterrogation - Is a captive being questioned? [Boolean]
 
 Returns:
+    [Nothing]
 
 Examples:
     (begin example)
-        _result = [] call btc_fnc_info_ask;
+        _action = [
+            "Interrogate_intel",
+            localize "STR_BTC_HAM_ACTION_INTEL_INTERROGATE","\a3\Ui_f\data\GUI\Cfg\CommunicationMenu\instructor_ca.paa",
+            btc_fnc_info_ask,
+            {Alive (_this select 0) && {captive (_this select 0)} && {[_this select 0] call ace_common_fnc_isAwake}},
+            nil,
+            [true]
+        ] call ace_interact_menu_fnc_createAction;
     (end)
 
 Author:
-    Giallustio
+    Giallustio, jmlane
 
 ---------------------------------------------------------------------------- */
 
 params [
-    ["_man", objNull, [objNull]],
-    ["_isInterrogate", false, [false]]
+    ["_target", objNull, [objNull]],
+    ["_player", player, [objNull]],
+    ["_args", [], [[]]]
 ];
 
-if !(_man call ace_medical_fnc_isInStableCondition) exitWith {
+_args params [
+    ["_isInterrogation", false, [false]]
+];
+
+if !(_target call ace_medical_fnc_isInStableCondition) exitWith {
     private _complain = selectRandom [
         localize "STR_BTC_HAM_CON_INFO_ASK_WOUNDED1", //Help me!
         localize "STR_BTC_HAM_CON_INFO_ASK_WOUNDED2", //I am suffering!
         localize "STR_BTC_HAM_CON_INFO_ASK_WOUNDED3", //Injure!
         localize "STR_BTC_HAM_CON_INFO_ASK_WOUNDED4"  //I have open wound!
     ];
-    [name _man, _complain] call btc_fnc_showSubtitle;
+    [name _target, _complain] call btc_fnc_showSubtitle;
 };
 
-if ((_man getVariable ["btc_already_asked", false]) || (_man getVariable ["btc_already_interrogated", false])) exitWith {
-    [name _man, localize "STR_BTC_HAM_CON_INFO_ASK_ALLREADYANS"] call btc_fnc_showSubtitle; //I already answered to your question!
+if ((_target getVariable ["btc_already_asked", false]) || (_target getVariable ["btc_already_interrogated", false])) exitWith {
+    [name _target, localize "STR_BTC_HAM_CON_INFO_ASK_ALLREADYANS"] call btc_fnc_showSubtitle; //I already answered to your question!
 };
 
-if ((round random 3) >= 2 || !_isInterrogate) then {
-    _man setVariable ["btc_already_asked", true];
-    if (_isInterrogate) then {_man setVariable ["btc_already_interrogated", true, true];};
+if ((round random 3) >= 2 || !_isInterrogation) then {
+    _target setVariable ["btc_already_asked", true];
+    if (_isInterrogation) then {_target setVariable ["btc_already_interrogated", true, true];};
 };
 
 
@@ -58,14 +73,14 @@ private _rep = btc_int_ask_data;
 private _chance = (random 300) + (random _rep) + _rep/2;
 private _info = "";
 private _info_type = "";
-switch !(_isInterrogate) do {
+switch !(_isInterrogation) do {
     case (_chance < 200) : {_info_type = "NO";};
     case (_chance >= 200 && _chance < 600) : {_info_type = "FAKE";};
     case (_chance >= 600) : {_info_type = "REAL";};
 };
-if (_isInterrogate) then {_info_type = "REAL";};
+if (_isInterrogation) then {_info_type = "REAL";};
 if (_info_type isEqualTo "NO") exitWith {
-    [name _man, localize "STR_BTC_HAM_CON_INFO_ASK_NOINFO"] call btc_fnc_showSubtitle; //I've no information for you
+    [name _target, localize "STR_BTC_HAM_CON_INFO_ASK_NOINFO"] call btc_fnc_showSubtitle; //I've no information for you
 };
 
 btc_int_ask_data = nil;
@@ -85,13 +100,13 @@ switch (_info_type) do {
     case "REAL" : {
         switch (_info) do {
             case "TROOPS" : {
-                [name _man, true] spawn btc_fnc_info_troops;
+                [name _target, true] spawn btc_fnc_info_troops;
             };
             case "HIDEOUT" : {
-                [name _man, true] spawn btc_fnc_info_hideout_asked;
+                [name _target, true] spawn btc_fnc_info_hideout_asked;
             };
             case "CACHE" : {
-                [name _man, localize "STR_BTC_HAM_CON_INFO_ASK_CACHEMAP"] call btc_fnc_showSubtitle; //I'll show you some hint on the map
+                [name _target, localize "STR_BTC_HAM_CON_INFO_ASK_CACHEMAP"] call btc_fnc_showSubtitle; //I'll show you some hint on the map
                 sleep 2;
                 [true, 1] remoteExec ["btc_fnc_info_cache", 2];
             };
@@ -100,13 +115,13 @@ switch (_info_type) do {
     case "FAKE" : {
         switch (_info) do {
             case "TROOPS" : {
-                [name _man, false] spawn btc_fnc_info_troops;
+                [name _target, false] spawn btc_fnc_info_troops;
             };
             case "HIDEOUT" : {
-                [name _man, false] spawn btc_fnc_info_hideout_asked;
+                [name _target, false] spawn btc_fnc_info_hideout_asked;
             };
             case "CACHE" : {
-                [name _man, localize "STR_BTC_HAM_CON_INFO_ASK_CACHEMAP"] call btc_fnc_showSubtitle; //I'll show you some hint on the map
+                [name _target, localize "STR_BTC_HAM_CON_INFO_ASK_CACHEMAP"] call btc_fnc_showSubtitle; //I'll show you some hint on the map
                 sleep 2;
                 [false, 1] remoteExec ["btc_fnc_info_cache", 2];
             };

--- a/core/fnc/info/ask.sqf
+++ b/core/fnc/info/ask.sqf
@@ -115,7 +115,7 @@ btc_int_ask_data = nil;
             };
             case "CACHE" : {
                 [name _target, localize "STR_BTC_HAM_CON_INFO_ASK_CACHEMAP"] call btc_fnc_showSubtitle; //I'll show you some hint on the map
-                [_info_type isEqualTo "REAL", 1] remoteExec ["btc_fnc_info_cache", 2];
+                [_player, _info_type isEqualTo "REAL"] remoteExecCall ["btc_fnc_info_cache", 2];
             };
         };
     }, [_info_type, _target, _player]] call CBA_fnc_waitUntilAndExecute;

--- a/core/fnc/info/cache.sqf
+++ b/core/fnc/info/cache.sqf
@@ -3,45 +3,54 @@
 Function: btc_fnc_info_cache
 
 Description:
-    Fill me when you edit me !
+    Server-side cache info handler that populates player diary with cache information.
 
 Parameters:
-    _isReal - [Boolean]
-    _showHint - [Number]
+    _player - Player that has gained the information. [Object]
+    _isReal - Is the information accurate? [Boolean]
+    _cache - Cache object. [Object]
 
 Returns:
+    [Nothing].
 
 Examples:
     (begin example)
-        _result = [] call btc_fnc_info_cache;
+        [_player, _info_type isEqualTo "REAL"] remoteExecCall ["btc_fnc_info_cache", 2];
     (end)
 
 Author:
-    Giallustio
+    Giallustio, jmlane
 
 ---------------------------------------------------------------------------- */
 
 params [
+    ["_player", player, [objNull]],
     ["_isReal", true, [true]],
-    ["_showHint", 0, [0]],
     ["_cache", btc_cache_obj, [objNull]]
 ];
 
+// TODO: provide meaningful exit rather than nothing.
 if (isNull _cache) exitWith {};
 
-private _pos = [btc_cache_pos, btc_cache_info] call CBA_fnc_randPos;
-private _directId = 0;//owner _asker;
-
-if !(_isReal) then {
+private _pos = if (_isReal) then {
+    [btc_cache_pos, btc_cache_info] call CBA_fnc_randPos;
+} else {
     private _axis = getNumber (configfile >> "CfgWorlds" >> worldName >> "mapSize") / 2;
-    _pos = [[_axis, _axis, 0], btc_cache_info + _axis] call CBA_fnc_randPos;
+    [[_axis, _axis, 0], btc_cache_info + _axis] call CBA_fnc_randPos;
 };
 
-private _marker = createMarker [format ["_USER_DEFINED #%1/%2C/1", _directId, _pos], _pos];
-_marker setMarkerType "hd_dot";
-_marker setMarkerColor "ColorRed";
+[_player, [
+    localize "STR_HM_DIARY_INFO",
+    [
+        format ["%1T @ GRID %2", [dayTime] call BIS_fnc_timeToString, mapGridPosition _player],
+        format [localize "STR_HM_DIARY_INFO_BODY", mapGridPosition _pos]
+    ]
+]] remoteExecCall ["createDiaryRecord", _player];
 
-if (_showHint > 0) then {[1] remoteExec ["btc_fnc_show_hint", 0];};
+btc_cache_info = if (btc_cache_info < btc_info_cache_ratio) then {
+    btc_info_cache_ratio;
+} else {
+    btc_cache_info - btc_info_cache_ratio;
+};
 
-btc_cache_info = btc_cache_info - btc_info_cache_ratio;
-if (btc_cache_info < btc_info_cache_ratio) then {btc_cache_info = btc_info_cache_ratio;};
+nil

--- a/core/fnc/info/has_intel.sqf
+++ b/core/fnc/info/has_intel.sqf
@@ -73,7 +73,7 @@ if (_target getVariable ["intel", false] && !(_target getVariable ["btc_already_
     switch (true) do {
         case (_n > 0.95 && {_hideoutsRemain}) : {
             _hint = 4;
-            [true, 0] spawn btc_fnc_info_cache;
+            [_player, true] call btc_fnc_info_cache;
             [_player] call _hideoutInfo;
         };
         case (_n >= 0.8 && {_n <= 0.95} && {_hideoutsRemain}) : {
@@ -82,7 +82,7 @@ if (_target getVariable ["intel", false] && !(_target getVariable ["btc_already_
         };
         default {
             _hint = 1;
-            [true, 0] spawn btc_fnc_info_cache;
+            [_player, true] call btc_fnc_info_cache;
         };
     };
 };

--- a/core/fnc/info/has_intel.sqf
+++ b/core/fnc/info/has_intel.sqf
@@ -3,18 +3,27 @@
 Function: btc_fnc_info_has_intel
 
 Description:
-    Fill me when you edit me !
+    Remote (server-side) handler for btc_fnc_info_search_for_intel.
 
 Parameters:
-    _body - [Object]
-    _asker - [Object]
+    _target - Target of the interaction. [Object]
+    _player - The player who performed the interaction. [Object]
     _radius - Max radius from hideout for information [Number]
 
 Returns:
+    [Nothing].
 
 Examples:
     (begin example)
-        _result = [] call btc_fnc_info_has_intel;
+        [
+            btc_int_search_intel_time,
+            [_target, player, _radius],
+            {_this select 0 remoteExecCall ["btc_fnc_info_has_intel", 2]},
+            {},
+            _localizedTitle,
+            _condition,
+            ["isnotinside"]
+        ] call ace_common_fnc_progressBar;
     (end)
 
 Author:
@@ -52,9 +61,13 @@ if (_target getVariable ["intel", false] && !(_target getVariable ["btc_already_
         private _pos = [getPos _ho, _radius] call CBA_fnc_randPos;
         private _directId = owner _player;
 
-        private _marker = createMarker [format ["_USER_DEFINED #%1/%2H/1", _directId, _pos], _pos];
-        _marker setMarkerType "hd_dot";
-        _marker setMarkerColor "ColorRed";
+        [_player, [
+            localize "STR_HM_DIARY_INFO",
+            [
+                format ["%1T @ GRID %2", [dayTime] call BIS_fnc_timeToString, mapGridPosition _player],
+                format [localize "STR_HM_DIARY_INFO_BODY", mapGridPosition _pos]
+            ]
+        ]] remoteExecCall ["createDiaryRecord", _player];
     };
 
     switch (true) do {

--- a/core/fnc/info/hideout_asked.sqf
+++ b/core/fnc/info/hideout_asked.sqf
@@ -57,4 +57,7 @@ if (_is_real) then {
 if (btc_debug) then {_text = _text + " - " + str _is_real};
 
 [_name, _text] call btc_fnc_showSubtitle;
-player createDiaryRecord [localize "STR_BTC_HAM_CON_INFO_ASKHIDEOUT_DIARYLOG", [str(mapGridPosition player) + " - " + _name, _text]]; //Diary log
+player createDiaryRecord [
+    localize "STR_HM_DIARY_INFO",
+    [format ["%1T @ GRID %2 (%3)", [dayTime] call BIS_fnc_timeToString, mapGridPosition player, _name], _text]
+];

--- a/core/fnc/info/search_for_intel.sqf
+++ b/core/fnc/info/search_for_intel.sqf
@@ -3,20 +3,29 @@
 Function: btc_fnc_info_search_for_intel
 
 Description:
-    Fill me when you edit me !
+    ACE Interaction action handler for searching for information.
 
 Parameters:
-    _target - [Object]
+    _target - Target of the interaction. [Object]
+    _player - The player who performed the interaction. [Object]
+    _args - Custom arguments. [Array]
 
 Returns:
+    [Nothing].
 
 Examples:
     (begin example)
-        _result = [] call btc_fnc_info_search_for_intel;
+        _action = [
+            "Search_intel",
+            localize "STR_A3_Showcase_Marksman_BIS_tskIntel_title",
+            "\A3\ui_f\data\igui\cfg\simpleTasks\types\search_ca.paa",
+            btc_fnc_info_search_for_intel,
+            {!Alive (_this select 0)}
+        ] call ace_interact_menu_fnc_createAction;
     (end)
 
 Author:
-    Giallustio
+    Giallustio, jmlane
 
 ---------------------------------------------------------------------------- */
 

--- a/core/fnc/info/search_for_intel.sqf
+++ b/core/fnc/info/search_for_intel.sqf
@@ -45,4 +45,4 @@ private _condition = {
     _target distance _player < _radius
 };
 
-[btc_int_search_intel_time, [_target, player, _radius], {_this select 0 remoteExecCall ["btc_fnc_info_has_intel", 2]}, {}, _localizedTitle, _condition, ["isnotinside"]] call ace_common_fnc_progressBar;
+[btc_int_search_intel_time, [_target, player, _radius], {_this select 0 remoteExecCall ["btc_fnc_info_has_intel", 2]}, {}, localize "STR_BTC_HAM_CON_INFO_SEARCH_BAR", _condition, ["isnotinside"]] call ace_common_fnc_progressBar;

--- a/core/fnc/info/troops.sqf
+++ b/core/fnc/info/troops.sqf
@@ -53,4 +53,7 @@ if (_is_real) then {
 if (btc_debug) then {_text = _text + " - " + str _is_real};
 
 [_name, _text] call btc_fnc_showSubtitle;
-player createDiaryRecord [localize "STR_BTC_HAM_CON_INFO_ASKHIDEOUT_DIARYLOG", [str(mapGridPosition player) + " - " + _name, _text]]; //Diary log
+player createDiaryRecord [
+    localize "STR_HM_DIARY_INFO",
+    [format ["%1T @ GRID %2 (%3)", [dayTime] call BIS_fnc_timeToString, mapGridPosition player, _name], _text]
+];

--- a/core/fnc/int/add_actions.sqf
+++ b/core/fnc/int/add_actions.sqf
@@ -15,7 +15,7 @@ Examples:
     (end)
 
 Author:
-    Giallustio
+    Giallustio, jmlane
 
 ---------------------------------------------------------------------------- */
 
@@ -30,9 +30,23 @@ _action = ["request_delete", localize "str_a3_cfgvehicles_modulerespawnvehicle_f
 [player, 1, ["ACE_SelfActions", "Database"], _action] call ace_interact_menu_fnc_addActionToObject;
 
 //Intel
-_action = ["Search_intel", localize "STR_A3_Showcase_Marksman_BIS_tskIntel_title", "\A3\ui_f\data\igui\cfg\simpleTasks\types\search_ca.paa", {_this call btc_fnc_info_search_for_intel}, {!Alive (_this select 0)}] call ace_interact_menu_fnc_createAction;
+_action = [
+    "Search_intel",
+    localize "STR_A3_Showcase_Marksman_BIS_tskIntel_title",
+    "\A3\ui_f\data\igui\cfg\simpleTasks\types\search_ca.paa",
+    btc_fnc_info_search_for_intel,
+    {!Alive (_this select 0)}
+] call ace_interact_menu_fnc_createAction;
 {[_x, 0, ["ACE_MainActions"], _action] call ace_interact_menu_fnc_addActionToClass;} forEach (btc_type_units + btc_type_divers);
-_action = ["Interrogate_intel", localize "STR_BTC_HAM_ACTION_INTEL_INTERROGATE", "\a3\Ui_f\data\GUI\Cfg\CommunicationMenu\instructor_ca.paa", {[(_this select 0),true] spawn btc_fnc_info_ask;}, {Alive (_this select 0) && {[_this select 0] call ace_common_fnc_isAwake} && captive (_this select 0)}] call ace_interact_menu_fnc_createAction;
+
+_action = [
+    "Interrogate_intel",
+    localize "STR_BTC_HAM_ACTION_INTEL_INTERROGATE","\a3\Ui_f\data\GUI\Cfg\CommunicationMenu\instructor_ca.paa",
+    btc_fnc_info_ask,
+    {Alive (_this select 0) && {captive (_this select 0)} && {[_this select 0] call ace_common_fnc_isAwake}},
+    nil,
+    [true]
+] call ace_interact_menu_fnc_createAction;
 {[_x, 0, ["ACE_MainActions"], _action] call ace_interact_menu_fnc_addActionToClass;} forEach (btc_type_units + btc_type_divers);
 
 //Orders
@@ -57,7 +71,15 @@ _action = ["Civil_Go_away", localize "STR_BTC_HAM_ACTION_ORDERS_GOAWAY", "\A3\ui
     [_x, 0, ["ACE_MainActions", "Civil_Orders"], _action] call ace_interact_menu_fnc_addActionToClass;
     _action = ["Civil_Go_away", localize "STR_BTC_HAM_ACTION_ORDERS_GOAWAY", "\A3\ui_f\data\igui\cfg\simpleTasks\types\talk1_ca.paa", {[3, (_this select 0)] call btc_fnc_int_orders;}, {Alive (_this select 0)}] call ace_interact_menu_fnc_createAction;
     [_x, 0, ["ACE_MainActions", "Civil_Orders"], _action] call ace_interact_menu_fnc_addActionToClass;
-    _action = ["Ask_Info", localize "STR_BTC_HAM_ACTION_ORDERS_ASKINFO", "\A3\ui_f\data\igui\cfg\simpleTasks\types\talk_ca.paa", {[(_this select 0),false] spawn btc_fnc_info_ask;}, {Alive (_this select 0) && {[_this select 0] call ace_common_fnc_isAwake} && {side (_this select 0) isEqualTo civilian}}] call ace_interact_menu_fnc_createAction;
+    _action = [
+        "Ask_Info",
+        localize "STR_BTC_HAM_ACTION_ORDERS_ASKINFO",
+        "\A3\ui_f\data\igui\cfg\simpleTasks\types\talk_ca.paa",
+        btc_fnc_info_ask,
+        {Alive (_this select 0) && {side (_this select 0) isEqualTo civilian} && {[_this select 0] call ace_common_fnc_isAwake}},
+        nil,
+        [false]
+    ] call ace_interact_menu_fnc_createAction;
     [_x, 0, ["ACE_MainActions"], _action] call ace_interact_menu_fnc_addActionToClass;
     _action = ["Ask_Reputation", localize "STR_BTC_HAM_ACTION_ORDERS_ASKREP", "\A3\ui_f\data\igui\cfg\simpleTasks\types\talk_ca.paa", {[_this select 0] spawn btc_fnc_info_ask_reputation;}, {Alive (_this select 0) && {[_this select 0] call ace_common_fnc_isAwake} && {side (_this select 0) isEqualTo civilian}}] call ace_interact_menu_fnc_createAction;
     [_x, 0, ["ACE_MainActions"], _action] call ace_interact_menu_fnc_addActionToClass;

--- a/stringtable.xml
+++ b/stringtable.xml
@@ -1109,12 +1109,21 @@
                 <Portuguese>Não há esconderijo por aqui!</Portuguese>
                 <Chinesesimp>附近没有藏匿点!</Chinesesimp>
             </Key>
-            <Key ID="STR_BTC_HAM_CON_INFO_ASKHIDEOUT_DIARYLOG">
-                <Original>Diary log</Original>
-                <Spanish>Registro diario</Spanish>
-                <German>Gesprächsaufzeichnung</German>
-                <Portuguese>Relatório</Portuguese>
-                <Chinesesimp>日志</Chinesesimp>
+            <Key ID="STR_HM_DIARY_INFO">
+                <Original>Gathered Information</Original>
+                <English>Gathered Information</English>
+            </Key>
+            <Key ID="STR_HM_DIARY_INFO_README">
+                <Original>READ ME</Original>
+                <English>READ ME</English>
+            </Key>
+            <Key ID="STR_HM_DIARY_INFO_README_TEXT">
+                <Original>This is your personal log of gathered information. It &lt;t underline='1'&gt;does&#160;not&lt;/t&gt; save across sessions, nor does it sync to other players.&lt;br/&gt;&lt;br/&gt;In order to gain actionable intelligence from this gathered information, you must share it with your team to develop a comprehensive picture of the insurgency together.</Original>
+                <English>This is your personal log of gathered information. It &lt;t underline='1'&gt;does&#160;not&lt;/t&gt; save across sessions, nor does it sync to other players.&lt;br/&gt;&lt;br/&gt;In order to gain actionable intelligence from this gathered information, you must share it with your team to develop a comprehensive picture of the insurgency together.</English>
+            </Key>
+            <Key ID="STR_HM_DIARY_INFO_BODY">
+                <Original>Information gathered indicates an area of interest near grid %1.</Original>
+                <English>Information gathered indicates an area of interest near grid %1.</English>
             </Key>
             <Key ID="STR_BTC_HAM_CON_INFO_SEARCH_BAR">
                 <Original>Searching for intel . . .</Original>


### PR DESCRIPTION
All the magic markers from the original implementation of H&M have been replaced with a diary log—under "Gathered Information" on map screen—of areas of interest.

This should resolve the final component of #24.

A good follow-up task would be a clean-up of the hint and subtitle functions, as well as the stringtable entries related to "intel."